### PR TITLE
Implemented file output

### DIFF
--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -1,1 +1,5 @@
+certifi==2024.12.14
+charset-normalizer==3.4.0
+idna==3.10
 requests==2.31.0
+urllib3==2.3.0

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 from getopt import GetoptError, gnu_getopt
+import json
 import os
 import sys
 import requests
@@ -46,6 +47,14 @@ def main(args):
         'hosting': 'Hosting/Colocated/Data Center',
     }
     response = get_api_data(args)
+    if len(args['output']) > 0:
+        output_path = args['output']
+        response_json = json.dumps(response, indent=4)
+        with open(output_path, 'w') as file:
+            file.write(response_json)
+
+        sys.exit(0)
+
     ip = response['query']
     response.pop('query')
     print(f'    IP Geolocation data for {ip}')
@@ -156,10 +165,13 @@ def parse_args(argv):
             sys.exit(0)
 
         elif opt in ('-o', '--output'):
-            if os.path.isdir(arg):
-                args['output'] = os.path.abspath(arg)
+            if os.path.isdir(os.path.dirname(os.path.abspath(arg))):
+                if arg[-5:] != ".json":
+                    args['output'] = f"{os.path.abspath(arg)}.json"
+                else:
+                    args['output'] = os.path.abspath(arg)
             else:
-                print(f'"{arg}" is not a valid file location. Please try again.\n')
+                print(f'"{arg}" is not a valid file location. Please try again.')
                 sys.exit(1)
 
             # -f --fields handling
@@ -175,7 +187,7 @@ def parse_args(argv):
             if os.path.isfile(arg):
                 args['fields'] = generate_csv_numeric('', arg)
             else:
-                print(f'"{arg}" is not a valid file. Please try again.\n')
+                print(f'"{arg}" is not a valid file. Please try again.')
                 sys.exit(1)
 
     return args

--- a/src/main.py
+++ b/src/main.py
@@ -141,14 +141,15 @@ def parse_args(argv):
     args = {
         # IP address to trace
         'ip': '',
-        # Output file location
+        # Output file (if any)
         'output': '',
         # Fields to request
         'fields': 1632249,
     }
 
     try:
-        opts, _args = gnu_getopt(argv, 'o:hAf:F:', ['output=', 'fields=', 'field-file='])
+        opts, _args = gnu_getopt(argv, 'o:hAf:F:', ['output=', 'fields=',
+                                                    'field-file='])
     except GetoptError:
         print_help_text()
         sys.exit(1)
@@ -171,7 +172,7 @@ def parse_args(argv):
                 else:
                     args['output'] = os.path.abspath(arg)
             else:
-                print(f'"{arg}" is not a valid file location. Please try again.')
+                print(f'"{arg}" is not a valid file path. Please try again.')
                 sys.exit(1)
 
             # -f --fields handling


### PR DESCRIPTION
File output functionality is implemented, previously the `-o` and `--output` flags did nothing.

File output is only implemented to output JSON, and directly outputs the JSON response from the api. If this is insufficient for user purposes, this can be expanded to more formats and with more functionality, but I don't currently plan to add anything more to it until that desire is made apparent.