### PR TITLE
Added more detailed .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
+# Directories to ignore
 lib/venv/
+build/
+
+# Files to ignore
+clip
+*.spec


### PR DESCRIPTION
Updated .gitignore file to account for the new changes to the build toolchain. Now the build directory, `clip` binary, and PyInstaller spec files should be ignored by git.