### PR TITLE
Add Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 # Files to ignore
 clip
 *.spec
+*.exe

--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ clip --help
 ```
 
 ### Installation
-Make sure `git`, `python3`, and `make` are installed on your system. Currently, this means Windows is not supported, but there are plans to support it eventually!
+**For installing on Windows, please see [this document](./Windows-Installation.md)**
+
+The following installation instructions are for Linux specifically, but are most likely applicable to other POSIX-compatible systems like macOS or *BSD's.
+
+Make sure `git`, `python3`, and `make` are installed on your system (`gmake` for BSD systems)
 
 Navigate to where you want to keep the files for clip and run the following command:
 ```bash
@@ -82,7 +86,6 @@ If you need the `clip` binary to be installed elsewhere, just change the `BIN_DI
 ```sh
 BIN_DIR = /usr/bin
 ```
-
 
 ### Disclaimer
 Do not use this program in any way for illicit purposes such as doxxing or harassment.

--- a/Windows-Installation.md
+++ b/Windows-Installation.md
@@ -1,0 +1,34 @@
+# CLIp Windows Installation
+
+Open a command prompt window (Windows Key + R then type `cmd`) and use `cd` to navigate to the directory where you want to keep the files for CLIp.
+```sh
+cd Documents
+```
+
+Before prcoeeding, make sure you have `git`, and `python` installed. If not, install them using the `winget` utility (You may need to install `winget` from the Microsoft Store):
+```sh
+winget install git.git
+```
+```sh
+winget install python3
+```
+
+Clone the repository and `cd` into it:
+```sh
+git clone https://github.com/Moonlight1211/clip && cd clip
+```
+
+Type `win-build` to run the build script:
+```sh
+win-build
+```
+Once the script says `Done!`, the program has been built and is ready to be used immediately!
+
+Unfortunately, there are no further installation steps to take; Windows comes with another utility called `clip` pre-installed that will override calls to our `CLIp`. Unless you want to delete that program/remove it from your `PATH` variable, your best bet for using `CLIp` is to either move the binary (`clip.exe`) to where you need it and then calling it directly:
+```sh
+.\clip.exe -f country,timezone 8.8.8.8
+```
+Or to rename the file to something more distinct and call it normally:
+```sh
+winclip -o response.json -f country,lon,lat
+```

--- a/win-build.bat
+++ b/win-build.bat
@@ -1,0 +1,33 @@
+:: Windows installation script for CLIp
+:: Please report any issues to https://github.com/Moonlight1211/clip/issues
+@echo OFF
+
+:: Virtual environment directory
+set venv_dir=lib\venv
+:: Options used in PyInstaller operation
+set pyinst_opts=-F -n clip --specpath src --distpath . --log-level ERROR
+
+:: If the venv doesn't exist, create one and install all dependencies
+if not exist %venv_dir%\ (
+    :: Create new Python virtual environment
+    python -m venv %venv_dir%
+    :: Activate the virtual environment
+    call %venv_dir%\Scripts\activate.bat
+    :: Install required dependencies
+    pip install -q -r lib\requirements.txt
+) else (
+    :: Venv exists, so just activate the virtual environment
+    call %venv_dir%\Scripts\activate.bat
+)
+
+:: Run PyInstaller to build program
+echo Building...
+pyinstaller %pyinst_opts% src\main.py
+
+:: Deactive the virtual environment
+call deactivate
+:: Clean up build files
+rmdir /S /Q build
+del src\*.spec
+:: Inform user that the operation is done
+echo Done!


### PR DESCRIPTION
Adds a script and documentation file to allow Windows users to build and use the application. Formal installation on Windows is still unsupported because another program called `clip` already exists in Windows, and the CLI-centric functionality of our `CLIp` program means it's probably better existing as a file that can be run.

Closes #8